### PR TITLE
feat: adopt angular material layout on home page

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -47,7 +47,9 @@
               }
             ],
             "styles": [
-              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css",
+              {
+                "input": "src/theme/material-theme.scss"
+              },
               {
                 "input": "src/theme/variables.scss"
               },
@@ -131,7 +133,9 @@
             "tsConfig": "tsconfig.spec.json",
             "karmaConfig": "karma.conf.js",
             "styles": [
-              "./node_modules/@angular/material/prebuilt-themes/indigo-pink.css"
+              {
+                "input": "src/theme/material-theme.scss"
+              }
             ],
             "scripts": [],
             "assets": [

--- a/src/app/components/course-in-focus/course-in-focus.component.ts
+++ b/src/app/components/course-in-focus/course-in-focus.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
-import { CourseInFocus } from 'src/app/models/courseInFocus';
+import { CourseInFocus } from 'src/app/models/CourseInFocus';
 import { COFFEE_CONV_SLIDER_OPTIONS } from 'src/app/app.constants';
 
 @Component({

--- a/src/app/pages/home/home.module.ts
+++ b/src/app/pages/home/home.module.ts
@@ -2,6 +2,8 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { IonicModule } from '@ionic/angular';
+import { MatGridListModule } from '@angular/material/grid-list';
+import { LayoutModule } from '@angular/cdk/layout';
 import { AppCommonModule } from 'src/app/app-common.module';
 import { HomePageRoutingModule } from './home-routing.module';
 import { HomePage } from './home.page';
@@ -14,7 +16,9 @@ import { CourseInFocusComponent } from '../../components/course-in-focus/course-
     FormsModule,
     IonicModule,
     HomePageRoutingModule,
-    AppCommonModule
+    AppCommonModule,
+    MatGridListModule,
+    LayoutModule
   ],
   declarations: [HomePage, NgoInFocusComponent, CourseInFocusComponent]
 })

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -4,7 +4,7 @@
 <app-social-share-home style="z-index: 2"></app-social-share-home>
 <app-concent-popup *ngIf="viewConsentPopup" (accepted)="onAccept()"></app-concent-popup>
 
-<ion-content>
+<div class="content-container mat-typography">
   <div class="page-container">
     <!-- Hero Section -->
     <section class="hero">
@@ -19,41 +19,33 @@
     <!-- Life Elements -->
     <app-life-elements></app-life-elements>
 
-    <!-- News and Conversations -->
-    <ion-grid class="ion-padding-top">
-      <ion-row>
-        <ion-col size-xs="12" size-md="6" size-lg="8">
-          <app-breaking-news [newsList]="newsList$ | async"></app-breaking-news>
-        </ion-col>
-        <ion-col size-xs="12" size-md="6" size-lg="4">
-          <app-coffee-conversation
-            [coffeeConvList]="coffeeConversations$ | async"
-            [fromHomePage]="true">
-          </app-coffee-conversation>
-        </ion-col>
-      </ion-row>
+    <!-- News, Conversations, NGOs, Courses, Calendar, and Polls -->
+    <mat-grid-list [cols]="gridCols" rowHeight="fit" gutterSize="16">
+      <mat-grid-tile [colspan]="newsColSpan">
+        <app-breaking-news [newsList]="newsList$ | async"></app-breaking-news>
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="sidebarColSpan">
+        <app-coffee-conversation
+          [coffeeConvList]="coffeeConversations$ | async"
+          [fromHomePage]="true">
+        </app-coffee-conversation>
+      </mat-grid-tile>
 
-      <!-- NGOs and Courses -->
-      <ion-row>
-        <ion-col size-xs="12" size-md="6" size-lg="8">
-          <app-ngo-in-focus [ngosInFocus]="ngosInFocus$ | async"></app-ngo-in-focus>
-        </ion-col>
-        <ion-col size-xs="12" size-md="6" size-lg="4">
-          <app-course-in-focus [coursesInFocus]="coursesInFocus$ | async"></app-course-in-focus>
-        </ion-col>
-      </ion-row>
+      <mat-grid-tile [colspan]="newsColSpan">
+        <app-ngo-in-focus [ngosInFocus]="ngosInFocus$ | async"></app-ngo-in-focus>
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="sidebarColSpan">
+        <app-course-in-focus [coursesInFocus]="coursesInFocus$ | async"></app-course-in-focus>
+      </mat-grid-tile>
 
-      <!-- Calendar and Polls -->
-      <ion-row>
-        <ion-col size-xs="12" size-md="6" size-lg="8">
-          <app-env-calender></app-env-calender>
-        </ion-col>
-        <ion-col size-xs="12" size-md="6" size-lg="4">
-          <app-polls-widget></app-polls-widget>
-        </ion-col>
-      </ion-row>
-    </ion-grid>
+      <mat-grid-tile [colspan]="newsColSpan">
+        <app-env-calender></app-env-calender>
+      </mat-grid-tile>
+      <mat-grid-tile [colspan]="sidebarColSpan">
+        <app-polls-widget></app-polls-widget>
+      </mat-grid-tile>
+    </mat-grid-list>
   </div>
 
   <app-wiof-footer></app-wiof-footer>
-</ion-content>
+</div>

--- a/src/app/pages/home/home.page.scss
+++ b/src/app/pages/home/home.page.scss
@@ -85,19 +85,10 @@ $breakpoint-tablet: 767px;
   }
 }
 
-ion-content {
-  --background: #f7f9fc;
+.content-container {
+  background: #f7f9fc;
 }
 
 app-wiof-footer {
   margin-top: 2rem;
-}
-
-ion-grid {
-  --ion-grid-padding: 0;
-}
-
-/* Optional: Add spacing between rows */
-ion-row + ion-row {
-  margin-top: 1.5rem;
 }

--- a/src/app/pages/home/home.page.ts
+++ b/src/app/pages/home/home.page.ts
@@ -1,3 +1,4 @@
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 import { Component, OnInit } from '@angular/core';
 import { CoffeeConversationService } from 'src/app/services/coffee-conversation.service';
 import { NgoInFocusService } from 'src/app/services/ngo-in-focus.service';
@@ -5,7 +6,7 @@ import { Observable } from 'rxjs';
 import { CoffeeConversation } from 'src/app/models/CoffeeConversation';
 import { NgoInFocus } from 'src/app/models/NgoInFocus';
 import { CourseInFocusService } from 'src/app/services/course-in-focus.service';
-import { CourseInFocus } from 'src/app/models/courseInFocus';
+import { CourseInFocus } from 'src/app/models/CourseInFocus';
 import { NewsService } from 'src/app/services/news.service';
 import { News } from 'src/app/models/News';
 
@@ -20,12 +21,16 @@ export class HomePage implements OnInit {
   ngosInFocus$: Observable<NgoInFocus[]>;
   coursesInFocus$: Observable<CourseInFocus[]>;
   newsList$: Observable<News[]>;
+  gridCols = 1;
+  newsColSpan = 1;
+  sidebarColSpan = 1;
 
   constructor(
     private newsService: NewsService,
     private coffeeConversationService: CoffeeConversationService,
     private ngoService: NgoInFocusService,
-    private courseService: CourseInFocusService
+    private courseService: CourseInFocusService,
+    private breakpointObserver: BreakpointObserver
   ) {}
 
   ngOnInit(): void {
@@ -37,6 +42,28 @@ export class HomePage implements OnInit {
     this.coffeeConversations$ = this.coffeeConversationService.getCoffeeConversations();
     this.ngosInFocus$ = this.ngoService.getActiveNgosInFocus();
     this.coursesInFocus$ = this.courseService.getCoursesInFocus();
+
+    this.breakpointObserver
+      .observe([
+        Breakpoints.XSmall,
+        Breakpoints.Small,
+        Breakpoints.Medium,
+        Breakpoints.Large,
+        Breakpoints.XLarge,
+      ])
+      .subscribe((result) => {
+        if (result.breakpoints[Breakpoints.XSmall] || result.breakpoints[Breakpoints.Small]) {
+          this.gridCols = 1;
+          this.newsColSpan = this.sidebarColSpan = 1;
+        } else if (result.breakpoints[Breakpoints.Medium]) {
+          this.gridCols = 2;
+          this.newsColSpan = this.sidebarColSpan = 1;
+        } else {
+          this.gridCols = 12;
+          this.newsColSpan = 8;
+          this.sidebarColSpan = 4;
+        }
+      });
   }
 
   onAccept(): void {

--- a/src/theme/material-theme.scss
+++ b/src/theme/material-theme.scss
@@ -1,0 +1,17 @@
+@use '@angular/material' as mat;
+
+@include mat.core();
+
+$wiof-primary: mat.define-palette(mat.$indigo-palette);
+$wiof-accent: mat.define-palette(mat.$pink-palette, A200, A100, A400);
+$wiof-warn: mat.define-palette(mat.$red-palette);
+
+$wiof-theme: mat.define-light-theme((
+  color: (
+    primary: $wiof-primary,
+    accent: $wiof-accent,
+    warn: $wiof-warn,
+  ),
+));
+
+@include mat.all-component-themes($wiof-theme);


### PR DESCRIPTION
## Summary
- add custom Angular Material theme and wire it into global styles
- replace Ionic grid on Home page with responsive Angular Material grid list
- include necessary Angular Material modules and remove obsolete Ionic styles

## Testing
- `npm run lint` *(fails: Cannot find builder "@angular-devkit/build-angular:tslint")*
- `npm test` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b51fb96044832a81a5793d51a1f5cd