### PR TITLE
refactor about us profiles stream

### DIFF
--- a/src/app/pages/aboutus/aboutus.page.html
+++ b/src/app/pages/aboutus/aboutus.page.html
@@ -7,7 +7,7 @@
   </ion-toolbar>
   <ion-grid>
     <ion-row>
-      <!-- Loop through profiles using the observable -->
+      <!-- Loop through profiles using the observable and async pipe -->
       <ion-col
         class="ion-padding profile-card-container"
         size="12"

--- a/src/app/pages/aboutus/aboutus.page.ts
+++ b/src/app/pages/aboutus/aboutus.page.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { AboutUsService, AboutUsProfile } from '../../services/aboutus.service';
 import { Observable, of } from 'rxjs';
+import { switchMap, defaultIfEmpty, take } from 'rxjs/operators';
 import { aboutUsData } from './aboutus-mock';
 
 @Component({
@@ -14,13 +15,13 @@ export class AboutusPage implements OnInit {
   constructor(private aboutUsService: AboutUsService) {}
 
   ngOnInit() {
-    // Fetch profiles from Firebase
-    this.aboutUsProfiles$ = this.aboutUsService.getAboutUsProfiles();
-
-    this.aboutUsProfiles$.subscribe(data => {
-      if(data.length == 0) {
-        this.aboutUsProfiles$ = of(aboutUsData);
-      }
-    });
+    // Fetch profiles from Firebase and fall back to mock data if empty
+    this.aboutUsProfiles$ = this.aboutUsService.getAboutUsProfiles().pipe(
+      take(1),
+      switchMap((profiles) =>
+        profiles.length ? of(profiles) : of(aboutUsData)
+      ),
+      defaultIfEmpty(aboutUsData)
+    );
   }
 }


### PR DESCRIPTION
## Summary
- derive About Us profiles stream with RxJS operators and fallback to mock data
- bind profiles observable directly via async pipe

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b525282fcc832aafd58a387c456e2a