### PR TITLE
refactor: improve config service typing

### DIFF
--- a/src/app/config.service.ts
+++ b/src/app/config.service.ts
@@ -1,37 +1,29 @@
 import { Injectable } from '@angular/core';
-import {
-  AngularFirestore,
-  AngularFirestoreCollection
-} from '@angular/fire/compat/firestore';
-import { from, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { AngularFirestore } from '@angular/fire/compat/firestore';
+import { Observable, of } from 'rxjs';
+import { catchError } from 'rxjs/operators';
 import { FIREBASE_COLLECTION } from './app.constants';
+
+export interface Config {
+  file: string;
+  [key: string]: any;
+}
 
 @Injectable({
   providedIn: 'root'
 })
 export class ConfigService {
-  congifCollection: AngularFirestoreCollection<any>;
+  constructor(private database: AngularFirestore) {}
 
-  constructor(public database: AngularFirestore) {
-    this.congifCollection = this.database.collection(
-      FIREBASE_COLLECTION.CONFIG
-    );
-  }
-
-  getConfig(file: string): Observable<any> {
-    const configCollectionByCategory = this.database.collection(
-      FIREBASE_COLLECTION.CONFIG,
-      (ref) => ref.where('file', '==', file)
-    );
-    return configCollectionByCategory.snapshotChanges().pipe(
-      map((actions) =>
-        actions.map((a) => {
-          const data = a.payload.doc.data();
-          // data.id = a.payload.doc.id;
-          return data;
+  getConfig(file: string): Observable<Config[]> {
+    return this.database
+      .collection<Config>(FIREBASE_COLLECTION.CONFIG, ref => ref.where('file', '==', file))
+      .valueChanges()
+      .pipe(
+        catchError((error) => {
+          console.error('Error loading config', error);
+          return of([]);
         })
-      )
-    );
+      );
   }
 }


### PR DESCRIPTION
## Summary
- fix typo in ConfigService by introducing typed Config interface
- add error handling and use strongly typed Firestore query

## Testing
- `npm test` *(fails: No binary for Chrome browser on your platform)*
- `npm run lint` *(fails: Cannot find builder "@angular-devkit/build-angular:tslint")*


------
https://chatgpt.com/codex/tasks/task_e_68b52c243f34832a9c0e147194ce13c4